### PR TITLE
Use logger instead of print

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ deps:
 
 # Check for errors in Python files
 pylint: deps
-	find . | grep .py | grep -v .pyc | xargs pylint -E
+	find . | grep .py$$ | xargs pylint -E
 
 lint: deps
 	pep8 --config ./pep8 . || true

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ release:
 
 deps:
 	pip install -r requirements-dev.txt
-	# python setup.py develop
+
+# Check for errors in Python files
+pylint: deps
+	find . | grep .py | grep -v .pyc | xargs pylint -E
 
 lint: deps
 	pep8 --config ./pep8 . || true
@@ -19,5 +22,5 @@ lint: deps
 format: deps
 	autopep8 -i -r -j0 -a --experimental --max-line-length 100 --indent-size 2 .
 
-test: deps
+test: deps pylint
 	nosetests test

--- a/ebs_snapshots/backup_config.py
+++ b/ebs_snapshots/backup_config.py
@@ -49,7 +49,7 @@ class BackupConfig:
             self._validate_config(new_config)
             self.config = new_config
         except Exception as e:
-            logging.info(kayvee.formatLog("ebs-snapshots", "warning", "unable to load backup config", {"path": self.path, "error": str(e)}))
+            logging.warning(kayvee.formatLog("ebs-snapshots", "warning", "unable to load backup config", {"path": self.path, "error": str(e)}))
 
         return self.config
 

--- a/ebs_snapshots/backup_config.py
+++ b/ebs_snapshots/backup_config.py
@@ -1,5 +1,6 @@
 import jsonschema
 import kayvee
+import logging
 
 schema = {
     "type": "object",
@@ -45,6 +46,6 @@ class BackupConfig:
             self._validate_config(new_config)
             self.config = new_config
         except Exception as e:
-            print kayvee.formatLog("ebs-snapshots", "warning", "unable to load backup config", {"path": self.path, "error": str(e)})
+            logging.info(kayvee.formatLog("ebs-snapshots", "warning", "unable to load backup config", {"path": self.path, "error": str(e)}))
 
         return self.config

--- a/ebs_snapshots/backup_config.py
+++ b/ebs_snapshots/backup_config.py
@@ -32,6 +32,9 @@ class BackupConfig:
         ...
     }
     """
+
+    path = None
+
     @classmethod
     def _validate_config(cls, new_config):
         """ Raises exception if config loaded from file doesn't match expected schema """
@@ -49,3 +52,6 @@ class BackupConfig:
             logging.info(kayvee.formatLog("ebs-snapshots", "warning", "unable to load backup config", {"path": self.path, "error": str(e)}))
 
         return self.config
+
+    def refresh(self):
+      raise NotImplementedError("refresh() must be implemented in subclasses")

--- a/ebs_snapshots/ebs_snapshots_daemon.py
+++ b/ebs_snapshots/ebs_snapshots_daemon.py
@@ -5,6 +5,7 @@ from s3_backup_config import S3BackupConfig
 import snapshot_manager
 from boto import ec2
 import kayvee
+import logging
 
 aws_access_key_id = os.environ['AWS_ACCESS_KEY_ID']
 aws_secret_access_key = os.environ['AWS_SECRET_ACCESS_KEY']
@@ -24,7 +25,7 @@ def create_snapshots(backup_conf):
     ec2_connection = ec2.connect_to_region(
         aws_region, aws_access_key_id=aws_access_key_id, aws_secret_access_key=aws_secret_access_key)
     for volume, params in backup_conf.get().iteritems():
-        print kayvee.formatLog("ebs-snapshots", "info", "about to take ebs snapshot {} - {}".format(volume, params))
+        logging.info(kayvee.formatLog("ebs-snapshots", "info", "about to take ebs snapshot {} - {}".format(volume, params)))
         interval = params.get('interval', 'daily')
         max_snapshots = params.get('max_snapshots', 0)
         name = params.get('name', '')

--- a/ebs_snapshots/snapshot_manager.py
+++ b/ebs_snapshots/snapshot_manager.py
@@ -3,6 +3,7 @@ import datetime
 import yaml
 from boto.exception import EC2ResponseError
 import kayvee
+import logging
 
 """ Configure the valid backup intervals """
 VALID_INTERVALS = [
@@ -27,7 +28,7 @@ def run(connection, volume_id, interval='daily', max_snapshots=0, name=''):
     try:
         volumes = connection.get_all_volumes([volume_id])
     except EC2ResponseError as error:
-        print kayvee.formatLog("ebs-snapshots", "error", "failed to connect to AWS", {"msg": error.message})
+        logging.info(kayvee.formatLog("ebs-snapshots", "error", "failed to connect to AWS", {"msg": error.message}))
         return
 
     for volume in volumes:
@@ -42,18 +43,18 @@ def _create_snapshot(connection, volume, name=''):
     :param volume: Volume to snapshot
     :returns: boto.ec2.snapshot.Snapshot -- The new snapshot
     """
-    print kayvee.formatLog("ebs-snapshots", "info", "creating new snapshot", {"volume": volume.id})
+    logging.info(kayvee.formatLog("ebs-snapshots", "info", "creating new snapshot", {"volume": volume.id}))
     snapshot = volume.create_snapshot(
         description="automatic snapshot by ebs-snapshots")
     if not name:
         name = '{}-snapshot'.format(volume.id)
     connection.create_tags(
         [snapshot.id], dict(Name=name, Creator='ebs-snapshots'))
-    print kayvee.formatLog("ebs-snapshots", "info", "created snapshot successfully", {
+    logging.info(kayvee.formatLog("ebs-snapshots", "info", "created snapshot successfully", {
         "name": name,
         "volume": volume.id,
         "snapshot": snapshot.id
-    })
+    }))
     return snapshot
 
 
@@ -67,10 +68,10 @@ def _ensure_snapshot(connection, volume, interval, name):
     :returns: None
     """
     if interval not in VALID_INTERVALS:
-        print kayvee.formatLog("ebs-snapshots", "warning", "invalid snapshotting interval", {
+        logging.info(kayvee.formatLog("ebs-snapshots", "warning", "invalid snapshotting interval", {
             "volume": volume.id,
             "interval": interval
-        })
+        }))
         return
 
     snapshots = connection.get_all_snapshots(filters={'volume-id': volume.id})
@@ -91,7 +92,7 @@ def _ensure_snapshot(connection, volume, interval, name):
         if delta_seconds < min_delta:
             min_delta = delta_seconds
 
-    print kayvee.formatLog("ebs-snapshots", "info", 'The newest snapshot for {} is {} seconds old'.format(volume.id, min_delta))
+    logging.info(kayvee.formatLog("ebs-snapshots", "info", 'The newest snapshot for {} is {} seconds old'.format(volume.id, min_delta)))
 
     if interval == 'hourly' and min_delta > 3600:
         _create_snapshot(connection, volume, name)
@@ -104,7 +105,7 @@ def _ensure_snapshot(connection, volume, interval, name):
     elif interval == 'yearly' and min_delta > 3600*24*365:
         _create_snapshot(connection, volume, name)
     else:
-        print kayvee.formatLog("ebs-snapshots", "info", "no snapshot needed", {"volume": volume.id})
+        logging.info(kayvee.formatLog("ebs-snapshots", "info", "no snapshot needed", {"volume": volume.id}))
 
 
 def _remove_old_snapshots(connection, volume, max_snapshots):
@@ -118,10 +119,10 @@ def _remove_old_snapshots(connection, volume, max_snapshots):
     """
     retention = max_snapshots
     if not type(retention) is int and retention >= 0:
-        print kayvee.formatLog("ebs-snapshots", "warning", "invalid max_snapshots value", {
+        logging.info(kayvee.formatLog("ebs-snapshots", "warning", "invalid max_snapshots value", {
             "volume": volume.id,
             "max_snapshots": retention
-        })
+        }))
         return
     snapshots = connection.get_all_snapshots(filters={'volume-id': volume.id})
 
@@ -132,17 +133,17 @@ def _remove_old_snapshots(connection, volume, max_snapshots):
     snapshots = snapshots[:-int(retention)]
 
     if not snapshots:
-        print kayvee.formatLog("ebs-snapshots", "info", "no old snapshots to remove")
+        logging.info(kayvee.formatLog("ebs-snapshots", "info", "no old snapshots to remove"))
         return
 
     for snapshot in snapshots:
-        print kayvee.formatLog("ebs-snapshots", "info", "deleting snapshot", {"snapshot": snapshot.id})
+        logging.info(kayvee.formatLog("ebs-snapshots", "info", "deleting snapshot", {"snapshot": snapshot.id}))
         try:
             snapshot.delete()
         except EC2ResponseError as error:
-            print kayvee.formatLog("ebs-snapshots", "warning", "could not remove snapshot", {
+            logging.info(kayvee.formatLog("ebs-snapshots", "warning", "could not remove snapshot", {
                 "snapshot": snapshot.id,
                 "msg": error.message
-            })
+            }))
 
-    print kayvee.formatLog("ebs-snapshots", "info", "done deleting snapshots")
+    logging.info(kayvee.formatLog("ebs-snapshots", "info", "done deleting snapshots"))

--- a/ebs_snapshots/snapshot_manager.py
+++ b/ebs_snapshots/snapshot_manager.py
@@ -28,7 +28,7 @@ def run(connection, volume_id, interval='daily', max_snapshots=0, name=''):
     try:
         volumes = connection.get_all_volumes([volume_id])
     except EC2ResponseError as error:
-        logging.info(kayvee.formatLog("ebs-snapshots", "error", "failed to connect to AWS", {"msg": error.message}))
+        logging.error(kayvee.formatLog("ebs-snapshots", "error", "failed to connect to AWS", {"msg": error.message}))
         return
 
     for volume in volumes:
@@ -68,7 +68,7 @@ def _ensure_snapshot(connection, volume, interval, name):
     :returns: None
     """
     if interval not in VALID_INTERVALS:
-        logging.info(kayvee.formatLog("ebs-snapshots", "warning", "invalid snapshotting interval", {
+        logging.warning(kayvee.formatLog("ebs-snapshots", "warning", "invalid snapshotting interval", {
             "volume": volume.id,
             "interval": interval
         }))
@@ -119,7 +119,7 @@ def _remove_old_snapshots(connection, volume, max_snapshots):
     """
     retention = max_snapshots
     if not type(retention) is int and retention >= 0:
-        logging.info(kayvee.formatLog("ebs-snapshots", "warning", "invalid max_snapshots value", {
+        logging.warning(kayvee.formatLog("ebs-snapshots", "warning", "invalid max_snapshots value", {
             "volume": volume.id,
             "max_snapshots": retention
         }))
@@ -141,7 +141,7 @@ def _remove_old_snapshots(connection, volume, max_snapshots):
         try:
             snapshot.delete()
         except EC2ResponseError as error:
-            logging.info(kayvee.formatLog("ebs-snapshots", "warning", "could not remove snapshot", {
+            logging.warning(kayvee.formatLog("ebs-snapshots", "warning", "could not remove snapshot", {
                 "snapshot": snapshot.id,
                 "msg": error.message
             }))

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from ebs_snapshots import ebs_snapshots_daemon
 import sys
 import kayvee
 import logging
+logging.basicConfig(level=logging.INFO)
 
 if __name__ == "__main__":
     try:

--- a/main.py
+++ b/main.py
@@ -8,5 +8,5 @@ if __name__ == "__main__":
     try:
         ebs_snapshots_daemon.snapshot_timer()
     except Exception as e:
-        logging.info(kayvee.formatLog("ebs-snapshots", "error", "unknown exception", {"error": str(e)}))
+        logging.error(kayvee.formatLog("ebs-snapshots", "error", "unknown exception", {"error": str(e)}))
         sys.exit(1)

--- a/main.py
+++ b/main.py
@@ -1,10 +1,11 @@
 from ebs_snapshots import ebs_snapshots_daemon
 import sys
 import kayvee
+import logging
 
 if __name__ == "__main__":
     try:
         ebs_snapshots_daemon.snapshot_timer()
     except Exception as e:
-        print kayvee.formatLog("ebs-snapshots", "error", "unknown exception", {"error": str(e)})
+        logging.info(kayvee.formatLog("ebs-snapshots", "error", "unknown exception", {"error": str(e)}))
         sys.exit(1)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 nose>=1.0
 moto==0.3.9
 mock==1.0.1
+pylint==1.4.3


### PR DESCRIPTION
- Converts print statements to use `logger.info` instead. https://github.com/Clever/ebs-snapshots/commit/94e63f190419c4c0653bec5f74c2b2293d4a3028
- Also adds pylint, to more rigorously check for errors https://github.com/Clever/ebs-snapshots/commit/ac2cec9974574b777f349872b0c19d0af6c7a492