### PR TITLE
Allow boto to handle AWS credentials

### DIFF
--- a/ebs_snapshots/ebs_snapshots_daemon.py
+++ b/ebs_snapshots/ebs_snapshots_daemon.py
@@ -8,8 +8,6 @@ from boto import ec2
 import kayvee
 import logging
 
-aws_access_key_id = os.environ['AWS_ACCESS_KEY_ID']
-aws_secret_access_key = os.environ['AWS_SECRET_ACCESS_KEY']
 aws_region = os.environ['AWS_REGION']
 config_path = os.environ['BACKUP_CONFIG']
 
@@ -17,7 +15,7 @@ config_path = os.environ['BACKUP_CONFIG']
 def get_backup_conf(path):
     """ Gets backup config from file or S3 """
     if path.startswith("s3://"):
-        return S3BackupConfig(path, aws_access_key_id, aws_secret_access_key)
+        return S3BackupConfig(path)
     elif ":" in path:
         # config is YAML or JSON
         return InlineBackupConfig(path)
@@ -26,8 +24,7 @@ def get_backup_conf(path):
 
 
 def create_snapshots(backup_conf):
-    ec2_connection = ec2.connect_to_region(
-        aws_region, aws_access_key_id=aws_access_key_id, aws_secret_access_key=aws_secret_access_key)
+    ec2_connection = ec2.connect_to_region(aws_region)
     for volume, params in backup_conf.get().iteritems():
         logging.info(kayvee.formatLog("ebs-snapshots", "info", "about to take ebs snapshot {} - {}".format(volume, params)))
         interval = params.get('interval', 'daily')

--- a/ebs_snapshots/s3_backup_config.py
+++ b/ebs_snapshots/s3_backup_config.py
@@ -11,15 +11,13 @@ class S3BackupConfig(BackupConfig):
     config = {}
     path = ""
 
-    def __init__(self, path, aws_access_key_id, aws_secret_access_key):
+    def __init__(self, path):
         self.path = path
-        self.access_key = aws_access_key_id
-        self.secret_key = aws_secret_access_key
 
     def refresh(self):
         """ Read s3 path and return parsed yml """
         # Get data from s3
-        s3_connection = connect_s3(self.access_key, self.secret_key)
+        s3_connection = connect_s3()
         s3_bucket = urlparse(self.path).hostname
         s3_path = urlparse(self.path).path[1:]  # no leading /
         bucket = s3_connection.lookup(s3_bucket)

--- a/test/test_s3_backup_config.py
+++ b/test/test_s3_backup_config.py
@@ -4,10 +4,6 @@ import yaml
 import boto
 from moto import mock_s3
 
-access_key = "fake"
-secret_key = "fake"
-
-
 class TestS3BackupConfig(unittest.TestCase):
 
     @mock_s3
@@ -15,7 +11,7 @@ class TestS3BackupConfig(unittest.TestCase):
         # if key doesn't exist, initialization should still succeed in case key
         # is written after daemon is started
         b = S3BackupConfig(
-            "s3://fake-bucket/fake-backup-conf.yml", access_key, secret_key)
+            "s3://fake-bucket/fake-backup-conf.yml")
 
     @mock_s3
     def test_refresh_errors_when_key_does_not_exist(self):
@@ -24,7 +20,7 @@ class TestS3BackupConfig(unittest.TestCase):
         k = boto.s3.key.Key(bucket)
 
         b = S3BackupConfig(
-            "s3://fake-bucket/does-not-exist.yml", access_key, secret_key)
+            "s3://fake-bucket/does-not-exist.yml")
         with self.assertRaises(boto.exception.S3ResponseError):
             b.refresh()
 
@@ -37,11 +33,11 @@ class TestS3BackupConfig(unittest.TestCase):
         k.set_contents_from_filename("test/not-valid-yaml.yml")
 
         b = S3BackupConfig(
-            "s3://fake-bucket/not-valid-yaml.yml", access_key, secret_key)
+            "s3://fake-bucket/not-valid-yaml.yml")
         with self.assertRaises(yaml.scanner.ScannerError):
             b.refresh()
         b = S3BackupConfig(
-            "s3://fake-bucket/not-valid-yaml.yml", access_key, secret_key)
+            "s3://fake-bucket/not-valid-yaml.yml")
 
     @mock_s3
     def test_get_data(self):
@@ -52,7 +48,7 @@ class TestS3BackupConfig(unittest.TestCase):
         k.set_contents_from_filename("test/example-volumes.yml")
 
         b = S3BackupConfig(
-            "s3://fake-bucket/example-volumes.yml", access_key, secret_key)
+            "s3://fake-bucket/example-volumes.yml")
         data = b.get()
         self.assertEqual(len(data), 3)
         self.assertEquals(

--- a/test/test_snapshot_manager.py
+++ b/test/test_snapshot_manager.py
@@ -8,7 +8,7 @@ class TestSnapshotManager(unittest.TestCase):
 
     @mock_ec2
     def test_ignore_attached_volumes(self):
-        conn = boto.connect_ec2('the_key', 'the_secret')
+        conn = boto.connect_ec2()
 
         # create a volumes
         volume = conn.create_volume(50, 'us-west-1a')


### PR DESCRIPTION
AFAIU boto should read ENV variables by default, setting AWS credentials via function args doesn't allow to use IAM instance profile creds. 

It works with my setup. @xavi- plz review