### PR TITLE
[INFRA-2909] increase memory allocation

### DIFF
--- a/launch/ebs-snapshots.yml
+++ b/launch/ebs-snapshots.yml
@@ -8,5 +8,5 @@ env:
 - BACKUP_CONFIG
 resources:
   cpu: 0.0  # no CPU to improve resource usage (https://clever.atlassian.net/browse/INFRA-2120)
-  max_mem: 0.02
+  max_mem: 0.05
 team: eng-infra


### PR DESCRIPTION
After a second AWS connection was introduced in #29, this app was hitting memory limits with previous memory threshold.  

[Clever-dev ebs-snapshots metrics](https://metrics.int.clever.com/dashboard/script/scripted_services.js?env=clever-dev&app=ebs-snapshots&from=1529613293794&to=1529707740054&orgId=1) show it using 94% memory before the change in #29; 119% after the change #29; 95% with a container crash with `--full-resources`, and 93% with no container crashes with this new increased memory limit and `--full-resources`.

![grafana metrics showing app at 94% memory usage before change in #29; 119% after change #29; and 93% after #30 ](https://user-images.githubusercontent.com/3254910/41802196-f684e8f8-7633-11e8-85fe-71a6c9b62ada.png)
