### PR TITLE
Revert "Revert "[INFRA-2909] make backup copies of ebs volume snapshots in another region""

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 
 ## Usage
 
+This requires `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, which should be set in `~/.aws/credentials`.
+
 ```
-AWS_ACCESS_KEY_ID=your_key \
-AWS_SECRET_ACCESS_KEY=your_secret \
 AWS_REGION=your_region \
+AWS_BACKUP_REGION=your_backup_region \
 BACKUP_CONFIG=s3://your-bucket/snapshots-config.yml \
 python main.py
 ```
@@ -47,6 +48,7 @@ You must specify these env vars in order to connect to AWS and to choose the con
 AWS_ACCESS_KEY_ID      # Your AWS Credentials
 AWS_SECRET_ACCESS_KEY  # Your AWS Credentials
 AWS_REGION             # AWS Region, e.g. us-west-1
+AWS_BACKUP_REGION	   # AWS Region for backups, e.g. us-west-2
 BACKUP_CONFIG          # Path to backup config. May be local file or s3 path (see "Configuration")
 ```
 

--- a/ebs_snapshots/ebs_snapshots_daemon.py
+++ b/ebs_snapshots/ebs_snapshots_daemon.py
@@ -5,10 +5,12 @@ from s3_backup_config import S3BackupConfig
 from inline_backup_config import InlineBackupConfig
 import snapshot_manager
 from boto import ec2
+import boto3
 import kayvee
 import logging
 
 aws_region = os.environ['AWS_REGION']
+aws_backup_region = os.environ['AWS_BACKUP_REGION']
 config_path = os.environ['BACKUP_CONFIG']
 
 
@@ -25,13 +27,15 @@ def get_backup_conf(path):
 
 def create_snapshots(backup_conf):
     ec2_connection = ec2.connect_to_region(aws_region)
+    ec2_backup_client = boto3.client("ec2", region_name=aws_backup_region)
     for volume, params in backup_conf.get().iteritems():
-        logging.info(kayvee.formatLog("ebs-snapshots", "info", "about to take ebs snapshot {} - {}".format(volume, params)))
+        logging.info(kayvee.formatLog("ebs-snapshots", "info", "about to evaluate ebs snapshots for {} - {}".format(volume, params), data={}))
         interval = params.get('interval', 'daily')
         max_snapshots = params.get('max_snapshots', 0)
         name = params.get('name', '')
         snapshot_manager.run(
-            ec2_connection, volume, interval, max_snapshots, name)
+            ec2_connection, ec2_backup_client, volume, interval, max_snapshots, name)
+
 
 
 def snapshot_timer(interval=300):

--- a/ebs_snapshots/snapshot_manager.py
+++ b/ebs_snapshots/snapshot_manager.py
@@ -267,7 +267,7 @@ def _remove_old_snapshots(connection, volume, max_snapshots):
     :param volume: Volume to check
     :returns: None
     """
-    logging.info(kayvee.formatLog("ebs-snapshots", "info", "removing old snapshots", data={"volume":volume}))
+    logging.info(kayvee.formatLog("ebs-snapshots", "info", "removing old snapshots", data={"volume":volume.id}))
 
     retention = max_snapshots
     if not type(retention) is int and retention >= 0:

--- a/ebs_snapshots/snapshot_manager.py
+++ b/ebs_snapshots/snapshot_manager.py
@@ -1,6 +1,7 @@
 """ Module handling the snapshots """
 import datetime
 import yaml
+import boto3
 from boto.exception import EC2ResponseError
 import kayvee
 import logging
@@ -14,11 +15,13 @@ VALID_INTERVALS = [
     u'yearly']
 
 
-def run(connection, volume_id, interval='daily', max_snapshots=0, name=''):
+def run(connection, backup_client, volume_id, interval='daily', max_snapshots=0, name=''):
     """ Ensure that we have snapshots for a given volume
 
     :type connection: boto.ec2.connection.EC2Connection
-    :param connection: EC2 connection object
+    :param connection: EC2 connection object for primary EBS region
+    :type backup_client: boto3.EC2.Client
+    :param backup_client: EC2 client for backup region
     :type volume_id: str
     :param volume_id: identifier for boto.ec2.volume.Volume
     :type max_snapshots: int
@@ -46,9 +49,9 @@ def run(connection, volume_id, interval='daily', max_snapshots=0, name=''):
         return
 
     for volume in volumes:
-        _ensure_snapshot(connection, volume, interval, name)
+        _ensure_snapshot(connection, backup_client, volume, interval, name)
         _remove_old_snapshots(connection, volume, max_snapshots)
-
+        _remove_old_snapshot_backups(backup_client, volume.id, max_snapshots)
 
 def _create_snapshot(connection, volume, name=''):
     """ Create a new snapshot
@@ -71,14 +74,63 @@ def _create_snapshot(connection, volume, name=''):
     }))
     return snapshot
 
+def _availability_zone_to_region_name(zone):
+    """Get the region_name from an availability zone by removing last letter
 
-def _ensure_snapshot(connection, volume, interval, name):
-    """ Ensure that a given volume has an appropriate snapshot
+    :type zone: str
+    :param zone: name of availability zone
+    :returns  str -- the name of the region
+    """
+    return zone[:-1]
+
+def _copy_snapshot(backup_client, volume, snapshot_id, name):
+    """ Copy a snapshot to another region
+
+    :type backup_client: boto3.EC2.Client
+    :param backup_client: EC2 client for backup region
+    :type volume: boto.ec2.volume.Volume
+    :param volume: Volume that snapshot is of
+    :type snapshot_id: str
+    :param snapshot_id: identifier for boto.ec2.snapshot.Snapshot (the snapshot to copy)
+    :returns: str -- the id of the copy
+    """
+    logging.info(kayvee.formatLog("ebs-snapshots", "info", "copying snapshot", {"volume": volume.id, "source_snapshot": snapshot_id}))
+    region = _availability_zone_to_region_name(volume.zone)
+    response = backup_client.copy_snapshot(
+        SourceRegion=region,
+        SourceSnapshotId=snapshot_id,
+        Encrypted=True,
+        Description='copy of {}'.format(snapshot_id))
+
+    backup_client.create_tags(
+        Resources=[response["SnapshotId"]],
+        Tags=[
+            {"Key":"Name", 'Value':name},
+            {"Key":"creator", 'Value':"ebs-snapshots"},
+            {"Key":"snapshot_source", 'Value':snapshot_id},
+            {"Key":"volume-id", 'Value':volume.id}
+        ]
+    )
+    logging.info(kayvee.formatLog("ebs-snapshots", "info", "copied snapshot successfully", {
+        "name": name,
+        "volume": volume.id,
+        "snapshot_source": snapshot_id,
+        "snapshot_copy": response["SnapshotId"]
+    }))
+
+    return response["SnapshotId"]
+
+def _ensure_snapshot(connection, backup_client, volume, interval, name):
+    """ Ensure that a given volume has appropriate snapshot(s) and backup snapshot(s)
 
     :type connection: boto.ec2.connection.EC2Connection
     :param connection: EC2 connection object
+    :type backup_client: boto3.EC2.Client
+    :param backup_client: EC2 client for backup region
     :type volume: boto.ec2.volume.Volume
     :param volume: Volume to check
+    :type name: str
+    :param name: a name to tag the snapshot(s) with
     :returns: None
     """
     if interval not in VALID_INTERVALS:
@@ -92,11 +144,18 @@ def _ensure_snapshot(connection, volume, interval, name):
 
     # Create a snapshot if we don't have any
     if not snapshots:
+        logging.info(kayvee.formatLog("ebs-snapshots", "info", "no snapshots found - creating snapshot", {"volume": volume.id}))
         _create_snapshot(connection, volume, name)
         return
 
+    latest_snapshot_id = None
     min_delta = 3600 * 24 * 365 * 10  # 10 years :)
+
+    latest_complete_snapshot_id = None
+    min_complete_snapshot_delta = 3600 * 24 * 365 * 10
+
     for snapshot in snapshots:
+        # Determine time since latest snapshot.
         timestamp = datetime.datetime.strptime(
             snapshot.start_time,
             '%Y-%m-%dT%H:%M:%S.000Z')
@@ -104,23 +163,100 @@ def _ensure_snapshot(connection, volume, interval, name):
             (datetime.datetime.utcnow() - timestamp).total_seconds())
 
         if delta_seconds < min_delta:
+            latest_snapshot_id = snapshot.id
             min_delta = delta_seconds
 
-    logging.info(kayvee.formatLog("ebs-snapshots", "info", 'The newest snapshot for {} is {} seconds old'.format(volume.id, min_delta)))
+        # Determine latest completed snapshot's id.
+        if snapshot.status == "completed" and delta_seconds < min_complete_snapshot_delta:
+            latest_complete_snapshot_id = snapshot.id
+            min_complete_snapshot_delta = delta_seconds
 
-    if interval == 'hourly' and min_delta > 3600:
-        _create_snapshot(connection, volume, name)
-    elif interval == 'daily' and min_delta > 3600*24:
-        _create_snapshot(connection, volume, name)
-    elif interval == 'weekly' and min_delta > 3600*24*7:
-        _create_snapshot(connection, volume, name)
-    elif interval == 'monthly' and min_delta > 3600*24*30:
-        _create_snapshot(connection, volume, name)
-    elif interval == 'yearly' and min_delta > 3600*24*365:
+    logging.info(kayvee.formatLog("ebs-snapshots", "info", 'The newest snapshot for {} is {} seconds old (snapshot {})'.format(volume.id, min_delta, latest_snapshot_id), data={"volume":volume.id}))
+    logging.info(kayvee.formatLog("ebs-snapshots", "info", 'The newest completed snapshot for {} is {} seconds old (snapshot {})'.format(volume.id, min_complete_snapshot_delta, latest_complete_snapshot_id), data={"volume":volume.id}))
+
+    # Create snapshot if latest is older than interval.
+    intervalToSeconds = {
+        u'hourly': 3600,
+        u'daily': 3600*24,
+        u'weekly': 3600*24*7,
+        u'monthly': 3600*24*30,
+        u'yearly': 3600*24*365,
+    }
+    if min_delta > intervalToSeconds[interval]:
         _create_snapshot(connection, volume, name)
     else:
-        logging.info(kayvee.formatLog("ebs-snapshots", "info", "no snapshot needed", {"volume": volume.id}))
+        logging.info(kayvee.formatLog("ebs-snapshots", "info", "no snapshot needed", {"volume": volume.id, "lastest_snapshot_id": latest_snapshot_id}))
 
+    # Make a backup copy of latest completed snapshot if there is one completed and latest is older than interval.
+    if latest_complete_snapshot_id is None:
+        logging.info(kayvee.formatLog("ebs-snapshots", "info", "waiting to create backup snapshot until snapshot is complete", {"volume": volume.id}))
+    elif min_complete_snapshot_delta > intervalToSeconds[interval]:
+        _copy_snapshot(backup_client, volume, latest_complete_snapshot_id, name)
+    elif not _has_backup(backup_client, volume):
+        # If the interval has not elapsed but there is a completed snapshot
+        # AND we don't yet have a backup, create one without waiting for latest to be older than interval.
+        logging.info(kayvee.formatLog("ebs-snapshots", "info", "no backup snapshots found - copying latest snapshot", {"volume": volume.id, "source_snapshot": latest_complete_snapshot_id}))
+        _copy_snapshot(backup_client, volume, latest_complete_snapshot_id, name)
+    else:
+        logging.info(kayvee.formatLog("ebs-snapshots", "info", "no backup snapshot needed", {"volume": volume.id}))
+
+def _has_backup(client, volume):
+    backup_snapshots = client.describe_snapshots(Filters=[
+        {
+            'Name': "tag:volume-id",
+            'Values': [volume.id]
+        }
+    ])
+    return len(backup_snapshots['Snapshots']) > 0
+
+def _remove_old_snapshot_backups(client, volume_id, max_snapshots):
+    """ Remove old snapshot backups
+
+    :type client: boto3.EC2.Client
+    :param client: EC2 client object
+    :type volume_id: str
+    :param volume_id: ID of volume to check
+    :returns: None
+    """
+    logging.info(kayvee.formatLog("ebs-snapshots", "info", "removing old backup snapshots", data={"volume":volume_id}))
+
+    retention = max_snapshots
+    if not type(retention) is int and retention >= 0:
+        logging.warning(kayvee.formatLog("ebs-snapshots", "warning", "invalid max_snapshots value", {
+            "volume": volume_id,
+            "max_snapshots": retention
+        }))
+        return
+
+    response = client.describe_snapshots(
+        Filters=[{ "Name": "tag:volume-id", "Values":[volume_id] }]
+    )
+    snapshots = response["Snapshots"]
+
+
+    # Sort the list based on the start time
+    snapshots.sort(key=lambda x: x["StartTime"])
+
+    # Remove snapshots we want to keep
+    snapshots = snapshots[:-int(retention)]
+
+    if not snapshots:
+        logging.info(kayvee.formatLog("ebs-snapshots", "info", "no old backup snapshots to remove", data={"volume":volume_id}))
+        return
+
+    ec2 = boto3.resource('ec2')
+    for snapshotInfo in snapshots:
+        snapshot = ec2.Snapshot(snapshotInfo["SnapshotId"])
+        logging.info(kayvee.formatLog("ebs-snapshots", "info", "deleting backup snapshot", {"snapshot": snapshot.id}))
+        try:
+            snapshot.delete()
+        except EC2ResponseError as error:
+            logging.warning(kayvee.formatLog("ebs-snapshots", "warning", "could not remove backup snapshot", {
+                "snapshot": snapshot.id,
+                "msg": error.message
+            }))
+
+    logging.info(kayvee.formatLog("ebs-snapshots", "info", "done deleting snapshot backups", data={"volume":volume_id}))
 
 def _remove_old_snapshots(connection, volume, max_snapshots):
     """ Remove old snapshots
@@ -131,6 +267,8 @@ def _remove_old_snapshots(connection, volume, max_snapshots):
     :param volume: Volume to check
     :returns: None
     """
+    logging.info(kayvee.formatLog("ebs-snapshots", "info", "removing old snapshots", data={"volume":volume}))
+
     retention = max_snapshots
     if not type(retention) is int and retention >= 0:
         logging.warning(kayvee.formatLog("ebs-snapshots", "warning", "invalid max_snapshots value", {
@@ -147,7 +285,7 @@ def _remove_old_snapshots(connection, volume, max_snapshots):
     snapshots = snapshots[:-int(retention)]
 
     if not snapshots:
-        logging.info(kayvee.formatLog("ebs-snapshots", "info", "no old snapshots to remove"))
+        logging.info(kayvee.formatLog("ebs-snapshots", "info", "no old snapshots to remove", data={"volume":volume.id}))
         return
 
     for snapshot in snapshots:
@@ -160,4 +298,4 @@ def _remove_old_snapshots(connection, volume, max_snapshots):
                 "msg": error.message
             }))
 
-    logging.info(kayvee.formatLog("ebs-snapshots", "info", "done deleting snapshots"))
+    logging.info(kayvee.formatLog("ebs-snapshots", "info", "done deleting snapshots", data={"volume":volume.id}))

--- a/launch/ebs-snapshots.yml
+++ b/launch/ebs-snapshots.yml
@@ -4,6 +4,7 @@ env:
 - AWS_ACCESS_KEY_ID
 - AWS_SECRET_ACCESS_KEY
 - AWS_REGION
+- AWS_BACKUP_REGION
 - BACKUP_CONFIG
 resources:
   cpu: 0.0  # no CPU to improve resource usage (https://clever.atlassian.net/browse/INFRA-2120)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask==0.10.1
 Flask-RESTful==0.3.1
 kayvee==2.0.2
 jsonschema==2.4.0
+boto3==1.7.19

--- a/test/test_snapshot_manager.py
+++ b/test/test_snapshot_manager.py
@@ -16,8 +16,10 @@ class TestSnapshotManager(unittest.TestCase):
         # mock out details for snapshot_manager.run
         snapshot_manager._ensure_snapshot = MagicMock()
         snapshot_manager._remove_old_snapshots = MagicMock()
+        snapshot_manager._remove_old_snapshot_backups = MagicMock()
 
         # run function for volume
         snapshot_manager.run(conn, volume.id, 'daily', 0, '')
         self.assertEqual(1, snapshot_manager._ensure_snapshot.call_count)
         self.assertEqual(1, snapshot_manager._remove_old_snapshots.call_count)
+        self.assertEqual(1, snapshot_manager._remove_old_snapshot_backups.call_count)


### PR DESCRIPTION
Reverts Clever/ebs-snapshots#31 and, in https://github.com/Clever/ebs-snapshots/pull/32/commits/e94da16179f3ece4ce48f593000f8e5aee385d74, and fixes log line that was causing `"Volume:------- is not JSON serializable"` error.

Related PR: https://github.com/Clever/ark-config/pull/1212