### PR TITLE
[INFRA-3218] circleci migration cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
     - run: sudo apt-get update
     - run: sudo apt-get install python-dev
     - run: sudo python -m pip install --upgrade pip==9.0.3
+    - run: make deps
     - run: make test
     - run:
         command: |-


### PR DESCRIPTION

JIRA: [INFRA-3218](https://clever.atlassian.net/browse/INFRA-3218)

Improve on the initial CircleCI translation:
- add back make deps (accidentally removed) 


previous: https://github.com/Clever/ebs-snapshots/pull/34/files